### PR TITLE
feat: add calendar-based reflection viewer and Google signup

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,9 @@
 
     <div id="signup-container" style="display: none;">
         <h2>Sign Up</h2>
+        <div id="signup-buttons">
+            <button id="google-signup">Sign up with Google</button>
+        </div>
         <form id="email-password-signup">
             <input type="email" id="signup-email" placeholder="Email" required>
             <input type="password" id="signup-password" placeholder="Password" required>
@@ -54,11 +57,14 @@
 
                     <button type="submit">Save Reflection</button>
                 </form>
-                <input type="date" id="calendar">
             </section>
 
             <section id="past-reflections">
                 <h2>Past Reflections</h2>
+                <div id="reflections-controls">
+                    <input type="date" id="calendar">
+                    <button id="show-all">Show All</button>
+                </div>
                 <div id="reflections-list"></div>
             </section>
         </main>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,6 @@
 // Import the functions you need from the SDKs you need
 import { initializeApp } from "https://www.gstatic.com/firebasejs/9.6.1/firebase-app.js";
-import { getAuth, GoogleAuthProvider, signInWithPopup, signInWithRedirect, createUserWithEmailAndPassword, signInWithEmailAndPassword, onAuthStateChanged, signOut } from "https://www.gstatic.com/firebasejs/9.6.1/firebase-auth.js";
+import { getAuth, GoogleAuthProvider, signInWithPopup, signInWithRedirect, getRedirectResult, createUserWithEmailAndPassword, signInWithEmailAndPassword, onAuthStateChanged, signOut } from "https://www.gstatic.com/firebasejs/9.6.1/firebase-auth.js";
 import { getFirestore, collection, addDoc, query, where, Timestamp, onSnapshot } from "https://www.gstatic.com/firebasejs/9.6.1/firebase-firestore.js";
 import { firebaseConfig } from './firebaseConfig.js';
 
@@ -23,6 +23,7 @@ const authContainer = document.getElementById('auth-container');
 const signupContainer = document.getElementById('signup-container');
 const appContainer = document.getElementById('app-container');
 const googleLoginButton = document.getElementById('google-login');
+const googleSignupButton = document.getElementById('google-signup');
 const emailPasswordLoginForm = document.getElementById('email-password-login');
 const emailPasswordSignupForm = document.getElementById('email-password-signup');
 const showSignupLink = document.getElementById('show-signup');
@@ -31,6 +32,9 @@ const logoutButton = document.getElementById('logout');
 const userEmailElement = document.getElementById('user-email');
 const calendarInput = document.getElementById('calendar');
 const reflectionsList = document.getElementById('reflections-list');
+const showAllButton = document.getElementById('show-all');
+
+let viewAll = false;
 
 // Show/Hide signup form
 showSignupLink.addEventListener('click', (e) => {
@@ -45,19 +49,36 @@ showLoginLink.addEventListener('click', (e) => {
     authContainer.style.display = 'block';
 });
 
-// Google Login
-googleLoginButton.addEventListener('click', async () => {
+// Google Login/Signup
+async function handleGoogleAuth() {
     try {
         await signInWithPopup(auth, provider);
     } catch (error) {
         if (error.code === 'auth/popup-blocked' || error.code === 'auth/cancelled-popup-request') {
-            await signInWithRedirect(auth, provider);
+            try {
+                await signInWithRedirect(auth, provider);
+            } catch (redirectError) {
+                handleGoogleError(redirectError);
+            }
         } else {
-            console.error('Google login error:', error);
-            alert(`Google login failed: ${error.message}`);
+            handleGoogleError(error);
         }
     }
-});
+}
+
+function handleGoogleError(error) {
+    console.error('Google login error:', error);
+    if (error.code === 'auth/unauthorized-domain') {
+        alert('Google login failed: unauthorized domain. Please add this domain in your Firebase console.');
+    } else {
+        alert(`Google login failed: ${error.message}`);
+    }
+}
+
+googleLoginButton.addEventListener('click', handleGoogleAuth);
+if (googleSignupButton) {
+    googleSignupButton.addEventListener('click', handleGoogleAuth);
+}
 
 // Email/Password Signup
 emailPasswordSignupForm.addEventListener('submit', async (e) => {
@@ -111,6 +132,9 @@ onAuthStateChanged(auth, (user) => {
         userEmailElement.textContent = user.email;
 
         // Set calendar to today and set up listener
+        viewAll = false;
+        calendarInput.style.display = 'block';
+        showAllButton.textContent = 'Show All';
         const today = new Date();
         calendarInput.value = today.toISOString().split('T')[0];
         setupReflectionsListener(today);
@@ -167,19 +191,7 @@ function setupReflectionsListener(date) {
         if (dayDocs.length === 0) {
             reflectionsList.innerHTML = '<p>No reflections for this day.</p>';
         } else {
-            dayDocs.forEach((doc) => {
-                const reflection = doc.data();
-                const reflectionEl = document.createElement('div');
-                const createdAtDate = reflection.createdAt.toDate();
-
-                reflectionEl.innerHTML = `
-                    <h3>Reflection from ${createdAtDate.toLocaleDateString()} at ${createdAtDate.toLocaleTimeString()}</h3>
-                    <p><strong>What did I do well today?</strong><br>${reflection.didWell}</p>
-                    <p><strong>What did I do poorly today?</strong><br>${reflection.didPoorly}</p>
-                    <p><strong>What will I improve tomorrow?</strong><br>${reflection.improveTomorrow}</p>
-                `;
-                reflectionsList.appendChild(reflectionEl);
-            });
+            dayDocs.forEach(renderReflectionDoc);
         }
     }, (error) => {
         console.error("Error with reflections listener: ", error);
@@ -190,11 +202,71 @@ function setupReflectionsListener(date) {
 calendarInput.addEventListener('change', () => {
     const dateParts = calendarInput.value.split('-').map(part => parseInt(part, 10));
     const selectedDate = new Date(dateParts[0], dateParts[1] - 1, dateParts[2]);
-    if (selectedDate) {
+    if (selectedDate && !viewAll) {
         setupReflectionsListener(selectedDate);
     }
 });
 
+
+function setupAllReflectionsListener() {
+    const user = auth.currentUser;
+    if (!user) return;
+
+    if (unsubscribeFromReflections) {
+        unsubscribeFromReflections();
+    }
+
+    reflectionsList.innerHTML = 'Loading...';
+
+    const q = query(
+        collection(db, "reflections"),
+        where("userId", "==", user.uid)
+    );
+
+    unsubscribeFromReflections = onSnapshot(q, (querySnapshot) => {
+        reflectionsList.innerHTML = '';
+        const docs = querySnapshot.docs
+            .sort((a, b) => b.data().createdAt.toMillis() - a.data().createdAt.toMillis());
+
+        if (docs.length === 0) {
+            reflectionsList.innerHTML = '<p>No reflections found.</p>';
+        } else {
+            docs.forEach(renderReflectionDoc);
+        }
+    }, (error) => {
+        console.error("Error with reflections listener: ", error);
+        reflectionsList.innerHTML = '<p>Error loading reflections.</p>';
+    });
+}
+
+function renderReflectionDoc(doc) {
+    const reflection = doc.data();
+    const reflectionEl = document.createElement('div');
+    const createdAtDate = reflection.createdAt.toDate();
+
+    reflectionEl.innerHTML = `
+        <h3>Reflection from ${createdAtDate.toLocaleDateString()} at ${createdAtDate.toLocaleTimeString()}</h3>
+        <p><strong>What did I do well today?</strong><br>${reflection.didWell}</p>
+        <p><strong>What did I do poorly today?</strong><br>${reflection.didPoorly}</p>
+        <p><strong>What will I improve tomorrow?</strong><br>${reflection.improveTomorrow}</p>
+    `;
+    reflectionsList.appendChild(reflectionEl);
+}
+
+showAllButton.addEventListener('click', () => {
+    viewAll = !viewAll;
+    if (viewAll) {
+        calendarInput.style.display = 'none';
+        showAllButton.textContent = 'Show by Date';
+        setupAllReflectionsListener();
+    } else {
+        calendarInput.style.display = 'block';
+        showAllButton.textContent = 'Show All';
+        const dateParts = calendarInput.value.split('-').map(part => parseInt(part, 10));
+        const selectedDate = new Date(dateParts[0], dateParts[1] - 1, dateParts[2]);
+        setupReflectionsListener(selectedDate);
+    }
+});
 
 // Reflection Form
 const reflectionForm = document.getElementById('daily-reflection');


### PR DESCRIPTION
## Summary
- move calendar into past reflections and let users list all entries
- add Google sign-up option and clearer unauthorized-domain errors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fe9b9fe40832ca729f3066b32c178